### PR TITLE
Github ActionsからGoogle Cloudのリソース作成を行う準備のTerraform #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.json
+.terraform*
+*.tfstate
+*.backup
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
 # test-gcp
+
+## レポジトリについて
+
+google cloudのTerraformの勉強用
+
+## ディレクトリ構成
+
+```
+|-- gh_oicd (github actionsからgoogle cloudのリソースを設定するための準備)
+```
+
+## 参考
+
+https://lab.mo-t.com/blog/terraform-github-actions

--- a/gh_oicd/README.md
+++ b/gh_oicd/README.md
@@ -1,0 +1,30 @@
+## ディレクトリについて
+
+github actionsからTerraformを実行するサービスアカウントと、接続するためのトークン発行のためのProviderとかを作成
+一度作成したらほぼ変更しないつもり
+
+## 初期設定
+
+サービスアカウント設定のTerraformの実行を行う`terraform-account`を用意する必要がある
+
+gcloud 実行コマンド
+```
+gcloud iam service-accounts create terraform-account --display-name "Used by Terraform on the local machine"
+
+gcloud projects add-iam-policy-binding {project-id} --member ${service-account-email} --role roles/editor
+
+gcloud projects add-iam-policy-binding {project-id} --member ${service-account-email} --role roles/iam.workloadIdentityPoolAdmin
+
+gcloud projects add-iam-policy-binding {project-id} --member ${service-account-email} --role roles/iam.securityAdmin
+
+gcloud projects add-iam-policy-binding {project-id} --member ${service-account-email} --role roles/iam.serviceAccountUser
+```
+
+## 参考
+https://github.com/hashicorp/terraform-provider-google/issues/11789
+
+poolを作成するときに`roles/iam.workloadIdentityPoolAdmin`が必要らしい
+
+https://stackoverflow.com/questions/65661144/getting-error-while-allowing-accounts-and-roles-in-terraform-for-gcp
+
+サービスアカウントにロールを渡すときに`roles/iam.securityAdmin`が必要らしい

--- a/gh_oicd/backend.tf
+++ b/gh_oicd/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  backend "gcs" {
+    credentials = "../service-account-112567.json"
+    bucket      = "terraform-state-112567"
+    prefix      = "gcp-test/gh_oicd"
+  }
+}

--- a/gh_oicd/main.tf
+++ b/gh_oicd/main.tf
@@ -1,0 +1,48 @@
+resource "google_service_account" "github_actions" {
+  account_id   = var.service_account_name
+  display_name = var.service_account_name
+  description  = "service account for github actions"
+}
+
+resource "google_iam_workload_identity_pool" "github_actions" {
+  provider                  = google-beta
+  project                   = var.project_id
+  workload_identity_pool_id = var.pool_id
+  display_name              = var.pool_id
+  description               = "workload identity pool for github actions"
+}
+
+# https://cloud.google.com/iam/docs/configuring-workload-identity-federation?hl=ja#oidc
+# プロバイダは、Sevurity Token Serviceで外部IDプロバイダの発行した認証情報とアクセストークンを交換し、
+# トークンと、プールに紐づいたサービスアカウントの権限を使って、GCPのリソースにアクセスする
+resource "google_iam_workload_identity_pool_provider" "github_actions" {
+  provider                           = google-beta
+  project                            = var.project_id
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github_actions.workload_identity_pool_id
+  workload_identity_pool_provider_id = var.provider_id
+  # GCPのJWTトークンにGithub Actionsが発行したJWTトークンの情報を紐づける
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"        # リポジトリ名と Git リファレンス
+    "attribute.actor"      = "assertion.actor"      # Github Actions を実行したユーザーアカウント
+    "attribute.repository" = "assertion.repository" # オーナーとリポジトリ名
+  }
+  # JWTトークンの発行元
+  oidc { issuer_uri = "https://token.actions.githubusercontent.com" }
+}
+
+resource "google_project_iam_member" "github_actions" {
+  project = var.project_id
+  member  = "serviceAccount:${google_service_account.github_actions.email}"
+  role    = "roles/iam.workloadIdentityUser"
+}
+
+resource "google_service_account_iam_binding" "github_actions" {
+  service_account_id = google_service_account.github_actions.name
+  role               = "roles/iam.workloadIdentityUser"
+  members = [
+    "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github_actions.name}/attribute.repository/${var.repository}"
+  ]
+  depends_on = [
+    google_project_iam_member.github_actions
+  ]
+}

--- a/gh_oicd/provider.tf
+++ b/gh_oicd/provider.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "4.60.0"
+    }
+    google = {
+      source  = "hashicorp/google"
+      version = "4.60.0"
+    }
+  }
+}
+
+provider "google-beta" {
+  credentials = file("../${var.project_id}.json")
+  project     = var.project_id
+  region      = "asia-northeast1"
+}
+
+provider "google" {
+  credentials = file("../${var.project_id}.json")
+  project     = var.project_id
+  region      = "asia-northeast1"
+}

--- a/gh_oicd/variable.tf
+++ b/gh_oicd/variable.tf
@@ -1,0 +1,19 @@
+variable "service_account_name" {
+  type = string
+}
+
+variable "project_id" {
+  type = string
+}
+
+variable "pool_id" {
+  type = string
+}
+
+variable "provider_id" {
+  type = string
+}
+
+variable "repository" {
+  type = string
+}


### PR DESCRIPTION
### 概要

Github ActionsからGoogle Cloudのリソース作成を行うために

- サービスアカウントの作成
- サービスアカウントに`roles/iam.workloadIdentityUser`の付与
- poolとproviderの作成

### 補足

この部分のTerraformの実行はローカルでやった


### 参照

#1 